### PR TITLE
Fix profile dropdown and improve tablet sidebar

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -75,7 +75,7 @@
 
   <div class="flex flex-col md:flex-row min-h-screen">
 
-    <aside id="leftRail" class="w-full md:w-48 bg-dark-panel border-r-2 border-dark-line md:sticky md:top-0 md:h-screen">
+    <aside id="leftRail" class="w-full md:w-48 bg-dark-panel border-r-2 border-dark-line md:sticky md:top-0 md:h-screen md:overflow-y-auto">
       <div class="flex flex-row md:flex-col relative">
 
         <div class="pfpH border-b-2 border-dark-line flex-shrink-0 flex items-center justify-center">
@@ -214,33 +214,6 @@
     </main>
   </div>
 
-  <script>
-    // Dropdowns: desktop + mobile
-    (function () {
-      const desktopBtn  = document.getElementById('pfpToggle');
-      const desktopMenu = document.getElementById('pfpMenu');
-      const mobileBtn   = document.getElementById('pfpToggleMobile');
-      const mobileMenu  = document.getElementById('pfpMenuMobile');
-
-      const toggle = (menu) => menu && menu.classList.toggle('hidden');
-      const hide   = (menu) => menu && menu.classList.add('hidden');
-
-      if (desktopBtn && desktopMenu) {
-        const on = (e)=>{ e.stopPropagation(); toggle(desktopMenu); hide(mobileMenu); };
-        desktopBtn.addEventListener('click', on);
-        desktopBtn.addEventListener('touchend', on);
-      }
-      if (mobileBtn && mobileMenu) {
-        const on = (e)=>{ e.stopPropagation(); toggle(mobileMenu); hide(desktopMenu); };
-        mobileBtn.addEventListener('click', on);
-        mobileBtn.addEventListener('touchend', on);
-      }
-
-      document.addEventListener('click', (e)=>{
-        if (desktopMenu && !desktopMenu.contains(e.target) && e.target !== desktopBtn) hide(desktopMenu);
-        if (mobileMenu  && !mobileMenu.contains(e.target)  && e.target !== mobileBtn)  hide(mobileMenu);
-      });
-    }());
-  </script>
+  <!-- main.js handles dropdowns -->
 </body>
 </html>

--- a/assets/main.js
+++ b/assets/main.js
@@ -2,25 +2,44 @@
 (function () {
   const $ = (sel) => document.querySelector(sel);
 
-  // 1) PFP dropdown
-  const pfpToggle = $("#pfpToggle");
-  const pfpMenu   = $("#pfpMenu");
+  // 1) PFP dropdowns (desktop + mobile)
+  const pfpToggle       = $("#pfpToggle");
+  const pfpMenu         = $("#pfpMenu");
+  const pfpToggleMobile = $("#pfpToggleMobile");
+  const pfpMenuMobile   = $("#pfpMenuMobile");
 
-  if (pfpToggle && pfpMenu) {
-    pfpToggle.addEventListener("click", (e) => {
+  function bindDropdown(btn, menu, hideMenus = []) {
+    if (!btn || !menu) return;
+    const on = (e) => {
       e.stopPropagation();
-      pfpMenu.classList.toggle("hidden");
-    });
-    document.addEventListener("click", (e) => {
-      if (!pfpMenu.classList.contains("hidden")) {
-        const inside = pfpMenu.contains(e.target) || pfpToggle.contains(e.target);
-        if (!inside) pfpMenu.classList.add("hidden");
+      menu.classList.toggle("hidden");
+      hideMenus.forEach((m) => m && m.classList.add("hidden"));
+    };
+    btn.addEventListener("click", on);
+    btn.addEventListener("touchend", on);
+  }
+
+  bindDropdown(pfpToggle, pfpMenu, [pfpMenuMobile]);
+  bindDropdown(pfpToggleMobile, pfpMenuMobile, [pfpMenu]);
+
+  document.addEventListener("click", (e) => {
+    [
+      [pfpMenu, pfpToggle],
+      [pfpMenuMobile, pfpToggleMobile],
+    ].forEach(([menu, toggle]) => {
+      if (menu && !menu.classList.contains("hidden")) {
+        const inside = menu.contains(e.target) || (toggle && toggle.contains(e.target));
+        if (!inside) menu.classList.add("hidden");
       }
     });
-    document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape") pfpMenu.classList.add("hidden");
-    });
-  }
+  });
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      if (pfpMenu) pfpMenu.classList.add("hidden");
+      if (pfpMenuMobile) pfpMenuMobile.classList.add("hidden");
+    }
+  });
 
   // 2) Keep header/left-rail border lines perfectly aligned
   function syncHeights() {

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
 
   <div class="flex flex-col md:flex-row min-h-screen">
 
-    <aside id="leftRail" class="w-full md:w-48 bg-dark-panel border-r-2 border-dark-line md:sticky md:top-0 md:h-screen">
+    <aside id="leftRail" class="w-full md:w-48 bg-dark-panel border-r-2 border-dark-line md:sticky md:top-0 md:h-screen md:overflow-y-auto">
       <div class="flex flex-row md:flex-col relative">
 
         <div class="pfpH border-b-2 border-dark-line flex-shrink-0 flex items-center justify-center">
@@ -261,45 +261,6 @@
     </main>
   </div>
 
-  <script>
-    // Load About content
-    (async () => {
-      try {
-        const res = await fetch('/assets/content/about.md', { cache: 'no-store' });
-        if (!res.ok) throw new Error('fail');
-        const md = await res.text();
-        document.getElementById('aboutBody').innerHTML = DOMPurify.sanitize(marked.parse(md));
-      } catch {
-        document.getElementById('aboutBody').textContent = "Couldn't load About.";
-      }
-    })();
-
-    // Dropdowns: desktop + mobile
-    (function () {
-      const desktopBtn  = document.getElementById('pfpToggle');
-      const desktopMenu = document.getElementById('pfpMenu');
-      const mobileBtn   = document.getElementById('pfpToggleMobile');
-      const mobileMenu  = document.getElementById('pfpMenuMobile');
-
-      const toggle = (menu) => menu && menu.classList.toggle('hidden');
-      const hide   = (menu) => menu && menu.classList.add('hidden');
-
-      if (desktopBtn && desktopMenu) {
-        const on = (e)=>{ e.stopPropagation(); toggle(desktopMenu); hide(mobileMenu); };
-        desktopBtn.addEventListener('click', on);
-        desktopBtn.addEventListener('touchend', on);
-      }
-      if (mobileBtn && mobileMenu) {
-        const on = (e)=>{ e.stopPropagation(); toggle(mobileMenu); hide(desktopMenu); };
-        mobileBtn.addEventListener('click', on);
-        mobileBtn.addEventListener('touchend', on);
-      }
-
-      document.addEventListener('click', (e)=>{
-        if (desktopMenu && !desktopMenu.contains(e.target) && e.target !== desktopBtn) hide(desktopMenu);
-        if (mobileMenu  && !mobileMenu.contains(e.target)  && e.target !== mobileBtn)  hide(mobileMenu);
-      });
-    }());
-  </script>
+  <!-- main.js handles About loading and dropdowns -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Handle desktop and mobile profile dropdowns centrally in `main.js`
- Remove duplicate inline scripts and make sidebar scrollable on tablets
- Apply same sidebar tweak to post layout for consistency

## Testing
- `bundle install --quiet --gemfile gemfile`
- `BUNDLE_GEMFILE=gemfile bundle exec jekyll build --quiet` *(fails: cannot load such file -- csv)*
- `jekyll build --quiet` *(fails: cannot load such file -- jekyll-feed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0887ed738832fbf9a473b22047635